### PR TITLE
performance improvements

### DIFF
--- a/dist/create-react-elements.js
+++ b/dist/create-react-elements.js
@@ -84,7 +84,7 @@
       attributes.children = createReactElements(childNodes);
     }
 
-    return _react["default"].createElement(tagname, attributes);
+    return /*#__PURE__*/_react["default"].createElement(tagname, attributes);
   }
 
   function createTextElement(element) {

--- a/dist/react-directive.js
+++ b/dist/react-directive.js
@@ -26,7 +26,7 @@
 
   function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
-  function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+  function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
 
   var ReactDirective = /*#__PURE__*/function () {
     function ReactDirective(ReactComponent, propNames, $compile) {
@@ -67,7 +67,7 @@
         this.render();
         this.$compile(element.contents())(scope.$parent); //re render on scope changes
 
-        this.elementScope.$watch(this.render.bind(this));
+        this.elementScope.$watchGroup(Object.keys(this.elementScope.$$isolateBindings), this.render.bind(this));
       }
     }, {
       key: "render",

--- a/src/react-directive.js
+++ b/src/react-directive.js
@@ -37,7 +37,7 @@ export default class ReactDirective {
     this.$compile(element.contents())(scope.$parent);
 
     //re render on scope changes
-    this.elementScope.$watch(this.render.bind(this));
+    this.elementScope.$watchGroup(Object.keys(this.elementScope.$$isolateBindings), this.render.bind(this));
   }
 
   render() {


### PR DESCRIPTION
**Summary:**

While running on a small project, everything seemed fine.

But our angularJs project that we are now slowly turning into a reactjs app, is a very complex project. 
When we started using `react2angularjs` everything seemed fine, until we started noticing that our react component was re-rendering all the time.

We noticed this after trying a console.log in our functional component. Something like this:
![Screenshot 2022-01-17 at 15 40 31](https://user-images.githubusercontent.com/96434187/149806727-4ffae6a1-517b-4ca3-a532-7af01bf83bed.png)

and this was the result:
https://user-images.githubusercontent.com/96434187/149810956-bad3e0ee-8718-413f-ba42-adc4d49b53e6.mp4

**Investigation of the problem**
So, after some debugging, we noticed that our component was re-rendering every time our angularjs app had a change (which in an app with pollings is constantly).

After looking at the lib we found this line of code at `react.directive.js` that does this `this.elementScope.$watch(this.render.bind(this));` 
That's exactly what `$watch` is doing. At every change, it calls the render method.

**Solution**
The solution that we have found is using `$watchGroup` that allows watching an array of expressions on the first parameter. Exemple below:
`this.elementScope.$watchGroup(Object.keys(this.elementScope.$$isolateBindings), this.render.bind(this));`
we get the bindings of the scope (react component) as we watch if one of does changes.

This way, we fixed the constant re-rendering.