### PR TITLE
Fix $compile:multilink error

### DIFF
--- a/dist/create-react-elements.js
+++ b/dist/create-react-elements.js
@@ -84,7 +84,7 @@
       attributes.children = createReactElements(childNodes);
     }
 
-    return _react["default"].createElement(tagname, attributes);
+    return /*#__PURE__*/_react["default"].createElement(tagname, attributes);
   }
 
   function createTextElement(element) {

--- a/dist/react-directive.js
+++ b/dist/react-directive.js
@@ -26,7 +26,7 @@
 
   function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
-  function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+  function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
 
   var ReactDirective = /*#__PURE__*/function () {
     function ReactDirective(ReactComponent, propNames, $compile) {
@@ -62,7 +62,7 @@
       key: "link",
       value: function link(scope, element, attrs, ctrl, transclude) {
         this.$container = element[0];
-        this.$children = transclude();
+        this.$children = transclude(function () {});
         this.elementScope = scope;
         this.render();
         this.$compile(element.contents())(scope.$parent); //re render on scope changes

--- a/src/react-directive.js
+++ b/src/react-directive.js
@@ -30,7 +30,7 @@ export default class ReactDirective {
 
   link(scope, element, attrs, ctrl, transclude) {
     const $container = element[0];
-    const $children = transclude();
+    const $children = transclude(function() {});
     const children = createReactElements($children);
 
     this.render(scope, $container, children);


### PR DESCRIPTION
**Issue:**
We were doing some tests using this directive inside a ng-repeat directive and we start having [compile errors](https://docs.angularjs.org/error/$compile/multilink) when we had two instances of a react-directive inside a ng-repeat directive.

Demo scenario:
< ng-repeat="item in $ctrl.items track by item.id">
    < react-2-angular-js-directive item="item"/>
< div>

**Investigation/solution:**
After some investigation we found out a possible solution to this problem:
On the [doc error page](https://docs.angularjs.org/error/$compile/multilink) it's referred that:
> "Linking an element as a clone multiple times is ok" 

We found out that sending a `cloneConnectFn` to the `transclude` function call [creates a clone](https://github.com/angular/angular.js/blob/master/src/ng/compile.js#L2468)

Don't know if there's a better solution to solve this issue, but please have a look at it. It worked for all our test scenarios.